### PR TITLE
feat: 보드 유저 확인

### DIFF
--- a/src/main/java/com/example/gamemate/domain/board/controller/BoardController.java
+++ b/src/main/java/com/example/gamemate/domain/board/controller/BoardController.java
@@ -6,10 +6,15 @@ import com.example.gamemate.domain.board.dto.BoardFindAllResponseDto;
 import com.example.gamemate.domain.board.dto.BoardFindOneResponseDto;
 import com.example.gamemate.domain.board.enums.BoardCategory;
 import com.example.gamemate.domain.board.service.BoardService;
+import com.example.gamemate.domain.user.entity.User;
+import com.example.gamemate.global.config.auth.CustomUserDetails;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -28,10 +33,11 @@ public class BoardController {
      */
     @PostMapping
     public ResponseEntity<BoardResponseDto> createBoard(
-            @Valid @RequestBody BoardRequestDto dto
+            @Valid @RequestBody BoardRequestDto dto,
+            @AuthenticationPrincipal CustomUserDetails customUserDetails
     ){
 
-        BoardResponseDto responseDto = boardService.createBoard(dto);
+        BoardResponseDto responseDto = boardService.createBoard(customUserDetails.getUser(), dto);
         return new ResponseEntity<>(responseDto, HttpStatus.CREATED);
     }
 
@@ -83,13 +89,14 @@ public class BoardController {
      * @return
      */
     @PatchMapping("/{id}")
-    public ResponseEntity<String> updateBoard(
+    public ResponseEntity<Void> updateBoard(
             @PathVariable Long id,
-            @Valid @RequestBody BoardRequestDto dto
+            @Valid @RequestBody BoardRequestDto dto,
+            @AuthenticationPrincipal CustomUserDetails customUserDetails
     ){
 
-        boardService.updateBoard(id, dto);
-        return new ResponseEntity<>("업데이트 되었습니다.", HttpStatus.NO_CONTENT);
+        boardService.updateBoard(customUserDetails.getUser(), id, dto);
+        return new ResponseEntity<>(HttpStatus.NO_CONTENT);
     }
 
     /**
@@ -98,11 +105,12 @@ public class BoardController {
      * @return
      */
     @DeleteMapping("/{id}")
-    public ResponseEntity<String> deleteBoard(
-            @PathVariable Long id
+    public ResponseEntity<Void> deleteBoard(
+            @PathVariable Long id,
+            @AuthenticationPrincipal CustomUserDetails customUserDetails
     ){
 
-        boardService.deleteBoard(id);
-        return new ResponseEntity<>("삭제 되었습니다", HttpStatus.NO_CONTENT);
+        boardService.deleteBoard(customUserDetails.getUser(), id);
+        return new ResponseEntity<>(HttpStatus.NO_CONTENT);
     }
 }

--- a/src/main/java/com/example/gamemate/domain/board/dto/BoardResponseDto.java
+++ b/src/main/java/com/example/gamemate/domain/board/dto/BoardResponseDto.java
@@ -3,17 +3,25 @@ package com.example.gamemate.domain.board.dto;
 import com.example.gamemate.domain.board.enums.BoardCategory;
 import lombok.Getter;
 
+import java.time.LocalDateTime;
+
 @Getter
 public class BoardResponseDto {
     private final Long id;
     private final BoardCategory category;
     private final String title;
     private final String content;
+    private final String nickname;
+    private final LocalDateTime createdAt;
+    private final LocalDateTime updatedAt;
 
-    public BoardResponseDto(Long id, BoardCategory category, String title, String content) {
+    public BoardResponseDto(Long id, BoardCategory category, String title, String content, String nickname, LocalDateTime createdAt, LocalDateTime updatedAt) {
         this.id = id;
         this.category = category;
         this.title = title;
         this.content = content;
+        this.nickname = nickname;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
     }
 }

--- a/src/main/java/com/example/gamemate/domain/board/entity/Board.java
+++ b/src/main/java/com/example/gamemate/domain/board/entity/Board.java
@@ -33,10 +33,11 @@ public class Board extends BaseEntity {
     @JoinColumn(name = "user_id")
     private User user;
 
-    public Board(BoardCategory category, String title, String content) {
+    public Board(BoardCategory category, String title, String content, User user) {
         this.category = category;
         this.title = title;
         this.content = content;
+        this.user = user;
     }
 
     public void updateBoard(BoardCategory category, String title, String content) {

--- a/src/main/java/com/example/gamemate/domain/board/service/BoardService.java
+++ b/src/main/java/com/example/gamemate/domain/board/service/BoardService.java
@@ -12,23 +12,19 @@ import com.example.gamemate.domain.comment.dto.CommentFindResponseDto;
 import com.example.gamemate.domain.comment.entity.Comment;
 import com.example.gamemate.domain.comment.repository.CommentRepository;
 import com.example.gamemate.domain.user.entity.User;
-import com.example.gamemate.global.config.auth.CustomUserDetails;
+import com.example.gamemate.global.constant.ErrorCode;
 import com.example.gamemate.global.exception.ApiException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.stream.Collectors;
 
-import static com.example.gamemate.global.constant.ErrorCode.BOARD_NOT_FOUND;
-import static com.example.gamemate.global.constant.ErrorCode.FORBIDDEN;
 
 @Service
 @RequiredArgsConstructor
@@ -93,7 +89,7 @@ public class BoardService {
         Pageable pageable = PageRequest.of(page, ListSize.LIST_SIZE.getSize(), Sort.by(Sort.Order.asc("createdAt")));
         // 게시글 조회
         Board findBoard = boardRepository.findById(id)
-                .orElseThrow(()->new ApiException(BOARD_NOT_FOUND));
+                .orElseThrow(()->new ApiException(ErrorCode.BOARD_NOT_FOUND));
 
         // 댓글 조회
         Page<Comment> comments = commentRepository.findByBoard(findBoard,pageable);
@@ -128,11 +124,11 @@ public class BoardService {
     public void updateBoard(User loginUser, Long id, BoardRequestDto dto) {
         // 게시글 조회
         Board findBoard = boardRepository.findById(id)
-                .orElseThrow(()->new ApiException(BOARD_NOT_FOUND));
+                .orElseThrow(()->new ApiException(ErrorCode.BOARD_NOT_FOUND));
 
         // 게시글 작성자와 로그인한 사용자 확인
         if(!findBoard.getUser().getId().equals(loginUser.getId())) {
-            throw new ApiException(FORBIDDEN);
+            throw new ApiException(ErrorCode.FORBIDDEN);
         }
 
         findBoard.updateBoard(dto.getCategory(),dto.getTitle(),dto.getContent());
@@ -147,11 +143,11 @@ public class BoardService {
     public void deleteBoard(User loginUser, Long id) {
         //게시글 조회
         Board findBoard = boardRepository.findById(id)
-                .orElseThrow(()->new ApiException(BOARD_NOT_FOUND));
+                .orElseThrow(()->new ApiException(ErrorCode.BOARD_NOT_FOUND));
 
         // 게시글 작성자와 로그인한 사용자 확인
         if(!findBoard.getUser().getId().equals(loginUser.getId())) {
-            throw new ApiException(FORBIDDEN);
+            throw new ApiException(ErrorCode.FORBIDDEN);
         }
 
         boardRepository.delete(findBoard);


### PR DESCRIPTION
1. 보드 생성 시에 유저 추가
2. 보드 수정, 삭제 시에 로그인한 유저 확인 추가
3. 보드 수정, 삭제 시에 return 값 Void로 변경

## #️⃣연관된 이슈

> #28 

## 📝작업 내용

> 보드 기능에서 유저 관련하여 필요한 부분 추가

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰 부탁드립니다.
