### PR TITLE
feat: 댓글 유저 확인

### DIFF
--- a/src/main/java/com/example/gamemate/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/example/gamemate/domain/comment/controller/CommentController.java
@@ -3,9 +3,11 @@ package com.example.gamemate.domain.comment.controller;
 import com.example.gamemate.domain.comment.dto.CommentRequestDto;
 import com.example.gamemate.domain.comment.dto.CommentResponseDto;
 import com.example.gamemate.domain.comment.service.CommentService;
+import com.example.gamemate.global.config.auth.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RequiredArgsConstructor
@@ -24,9 +26,10 @@ public class CommentController {
     @PostMapping
     public ResponseEntity<CommentResponseDto> createComment(
             @PathVariable Long boardId,
-            @RequestBody CommentRequestDto requestDto
+            @RequestBody CommentRequestDto requestDto,
+            @AuthenticationPrincipal CustomUserDetails customUserDetails
     ){
-        CommentResponseDto dto = commentService.createComment(boardId, requestDto);
+        CommentResponseDto dto = commentService.createComment(customUserDetails.getUser(),boardId, requestDto);
         return new ResponseEntity<>(dto, HttpStatus.CREATED);
     }
 
@@ -39,17 +42,19 @@ public class CommentController {
     @PatchMapping("/{id}")
     public ResponseEntity<Void> updateComment(
             @PathVariable Long id,
-            @RequestBody CommentRequestDto requestDto
+            @RequestBody CommentRequestDto requestDto,
+            @AuthenticationPrincipal CustomUserDetails customUserDetails
     ){
-        commentService.updateComment(id, requestDto);
+        commentService.updateComment(customUserDetails.getUser(), id, requestDto);
         return new ResponseEntity<>(HttpStatus.NO_CONTENT);
     }
 
     @DeleteMapping("/{id}")
     public ResponseEntity<Void> deleteComment(
-            @PathVariable Long id
+            @PathVariable Long id,
+            @AuthenticationPrincipal CustomUserDetails customUserDetails
     ){
-        commentService.deleteComment(id);
+        commentService.deleteComment(customUserDetails.getUser(), id);
         return new ResponseEntity<>(HttpStatus.NO_CONTENT);
     }
 }

--- a/src/main/java/com/example/gamemate/domain/comment/dto/CommentResponseDto.java
+++ b/src/main/java/com/example/gamemate/domain/comment/dto/CommentResponseDto.java
@@ -8,12 +8,14 @@ import java.time.LocalDateTime;
 public class CommentResponseDto {
     private final Long id;
     private final String content;
+    private final String nickname;
     private final LocalDateTime createdAt;
     private final LocalDateTime updatedAt;
 
-    public CommentResponseDto(Long id, String content, LocalDateTime createdAt, LocalDateTime updatedAt) {
+    public CommentResponseDto(Long id, String content, String nickname, LocalDateTime createdAt, LocalDateTime updatedAt) {
         this.id = id;
         this.content = content;
+        this.nickname = nickname;
         this.createdAt = createdAt;
         this.updatedAt = updatedAt;
     }

--- a/src/main/java/com/example/gamemate/domain/comment/entity/Comment.java
+++ b/src/main/java/com/example/gamemate/domain/comment/entity/Comment.java
@@ -27,9 +27,10 @@ public class Comment extends BaseEntity {
     @JoinColumn(name = "board_id")
     private Board board;
 
-    public Comment(String content, Board board) {
+    public Comment(String content, Board board, User user) {
         this.content = content;
         this.board = board;
+        this.user = user;
     }
 
     public void updateComment(String content) {


### PR DESCRIPTION
1. 댓글 생성 시에 유저 추가
2. 댓글 수정, 삭제 시에 로그인한 유저 확인 추가

## #️⃣연관된 이슈

> #33 

## 📝작업 내용

> 댓글 기능에서 유저 관련하여 필요한 부분 추가

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰 부탁드립니다.
