### PR TITLE
feat: 대댓글 기능 구현

### DIFF
--- a/src/main/java/com/example/gamemate/domain/board/dto/BoardFindOneResponseDto.java
+++ b/src/main/java/com/example/gamemate/domain/board/dto/BoardFindOneResponseDto.java
@@ -2,7 +2,6 @@ package com.example.gamemate.domain.board.dto;
 
 import com.example.gamemate.domain.board.enums.BoardCategory;
 import com.example.gamemate.domain.comment.dto.CommentFindResponseDto;
-import com.example.gamemate.domain.comment.entity.Comment;
 import lombok.Getter;
 
 import java.time.LocalDate;
@@ -15,16 +14,17 @@ public class BoardFindOneResponseDto {
     private final BoardCategory category;
     private final String title;
     private final String content;
-    //private final String nickname;
+    private final String nickname;
     private final LocalDateTime createdAt;
     private final LocalDateTime modifiedAt;
     private final List<CommentFindResponseDto> comments;
 
-    public BoardFindOneResponseDto(Long id, BoardCategory category, String title, String content, LocalDateTime createdAt, LocalDateTime modifiedAt, List<CommentFindResponseDto> comments) {
+    public BoardFindOneResponseDto(Long id, BoardCategory category, String title, String content, String nickname, LocalDateTime createdAt, LocalDateTime modifiedAt, List<CommentFindResponseDto> comments) {
         this.id = id;
         this.category = category;
         this.title = title;
         this.content = content;
+        this.nickname = nickname;
         this.createdAt = createdAt;
         this.modifiedAt = modifiedAt;
         this.comments = comments;

--- a/src/main/java/com/example/gamemate/domain/comment/dto/CommentFindResponseDto.java
+++ b/src/main/java/com/example/gamemate/domain/comment/dto/CommentFindResponseDto.java
@@ -1,20 +1,27 @@
 package com.example.gamemate.domain.comment.dto;
 
+import com.example.gamemate.domain.reply.dto.ReplyFindResponseDto;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Set;
 
 @Getter
 public class CommentFindResponseDto {
     private final Long commentId;
     private final String content;
+    private final String nickname;
     private final LocalDateTime createdAt;
     private final LocalDateTime updatedAt;
+    private final List<ReplyFindResponseDto> replies;
 
-    public CommentFindResponseDto(Long commentId, String content, LocalDateTime createdAt, LocalDateTime updatedAt) {
+    public CommentFindResponseDto(Long commentId, String content, String nickname, LocalDateTime createdAt, LocalDateTime updatedAt, List<ReplyFindResponseDto> replies) {
         this.commentId = commentId;
         this.content = content;
+        this.nickname = nickname;
         this.createdAt = createdAt;
         this.updatedAt = updatedAt;
+        this.replies = replies;
     }
 }

--- a/src/main/java/com/example/gamemate/domain/comment/entity/Comment.java
+++ b/src/main/java/com/example/gamemate/domain/comment/entity/Comment.java
@@ -1,11 +1,14 @@
 package com.example.gamemate.domain.comment.entity;
 
 import com.example.gamemate.domain.board.entity.Board;
+import com.example.gamemate.domain.reply.entity.Reply;
 import com.example.gamemate.domain.user.entity.User;
 import com.example.gamemate.global.common.BaseEntity;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.util.List;
 
 @Entity
 @Getter

--- a/src/main/java/com/example/gamemate/domain/reply/controller/ReplyController.java
+++ b/src/main/java/com/example/gamemate/domain/reply/controller/ReplyController.java
@@ -1,0 +1,67 @@
+package com.example.gamemate.domain.reply.controller;
+
+import com.example.gamemate.domain.reply.dto.ReplyRequestDto;
+import com.example.gamemate.domain.reply.dto.ReplyResponseDto;
+import com.example.gamemate.domain.reply.service.ReplyService;
+import com.example.gamemate.global.config.auth.CustomUserDetails;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/boards/{boardId}/comments/{commentId}/replies")
+public class ReplyController {
+
+    private final ReplyService replyService;
+
+    /**
+     * 대댓글 생성 API
+     * @param commentId
+     * @param requestDto
+     * @return
+     */
+    @PostMapping
+    public ResponseEntity<ReplyResponseDto> createReply(
+            @PathVariable Long commentId,
+            @Valid  @RequestBody ReplyRequestDto requestDto,
+            @AuthenticationPrincipal CustomUserDetails customUserDetails
+    ){
+        ReplyResponseDto dto = replyService.createReply(customUserDetails.getUser(), commentId, requestDto);
+        return new ResponseEntity<>(dto, HttpStatus.CREATED);
+    }
+
+    /**
+     * 대댓글 수정 API
+     * @param id
+     * @param requestDto
+     * @return
+     */
+    @PatchMapping("/{id}")
+    public ResponseEntity<Void> updateReply(
+        @PathVariable Long id,
+        @Valid @RequestBody ReplyRequestDto requestDto,
+        @AuthenticationPrincipal CustomUserDetails customUserDetails
+    ){
+        replyService.updateReply(customUserDetails.getUser(), id, requestDto);
+        return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+    }
+
+    /**
+     * 대댓글 삭제 API
+     * @param id
+     * @return
+     */
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteReply(
+            @PathVariable Long id,
+            @AuthenticationPrincipal CustomUserDetails customUserDetails
+    ){
+        replyService.deleteReply(customUserDetails.getUser(), id);
+        return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+    }
+}
+

--- a/src/main/java/com/example/gamemate/domain/reply/dto/ReplyFindResponseDto.java
+++ b/src/main/java/com/example/gamemate/domain/reply/dto/ReplyFindResponseDto.java
@@ -1,0 +1,25 @@
+package com.example.gamemate.domain.reply.dto;
+
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Set;
+
+@Getter
+public class ReplyFindResponseDto {
+    private final Long replyId;
+    private final String parentReplyName;
+    private final String content;
+    private final LocalDateTime createdAt;
+    private final LocalDateTime updatedAt;
+
+
+    public ReplyFindResponseDto(Long replyId, String parentReplyName, String content, LocalDateTime createdAt, LocalDateTime updatedAt) {
+        this.replyId = replyId;
+        this.parentReplyName = parentReplyName;
+        this.content = content;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+    }
+}

--- a/src/main/java/com/example/gamemate/domain/reply/dto/ReplyRequestDto.java
+++ b/src/main/java/com/example/gamemate/domain/reply/dto/ReplyRequestDto.java
@@ -1,0 +1,21 @@
+package com.example.gamemate.domain.reply.dto;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+@Getter
+public class ReplyRequestDto {
+    @NotBlank(message="댓글 내용을 입력하세요.")
+    private String content;
+
+    private Long parentReplyId;
+
+    public ReplyRequestDto(String content, Long parentReplyId) {
+        this.content = content;
+        this.parentReplyId = parentReplyId;
+    }
+
+    public ReplyRequestDto() {
+    }
+}

--- a/src/main/java/com/example/gamemate/domain/reply/dto/ReplyResponseDto.java
+++ b/src/main/java/com/example/gamemate/domain/reply/dto/ReplyResponseDto.java
@@ -1,0 +1,32 @@
+package com.example.gamemate.domain.reply.dto;
+
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class ReplyResponseDto {
+    private final Long id;
+    private final Long commentId;
+    private Long parentReplyId;
+    private final String content;
+    private final LocalDateTime createdAt;
+    private final LocalDateTime updatedAt;
+
+    public ReplyResponseDto(Long id, Long commentId, Long parentReplyId, String content, LocalDateTime createdAt, LocalDateTime updatedAt) {
+        this.id = id;
+        this.commentId = commentId;
+        this.parentReplyId = parentReplyId;
+        this.content = content;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+    }
+
+    public ReplyResponseDto(Long id, Long commentId, String content, LocalDateTime createdAt, LocalDateTime updatedAt) {
+        this.id = id;
+        this.commentId = commentId;
+        this.content = content;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+    }
+}

--- a/src/main/java/com/example/gamemate/domain/reply/entity/Reply.java
+++ b/src/main/java/com/example/gamemate/domain/reply/entity/Reply.java
@@ -1,0 +1,52 @@
+package com.example.gamemate.domain.reply.entity;
+
+import com.example.gamemate.domain.comment.entity.Comment;
+import com.example.gamemate.domain.user.entity.User;
+import com.example.gamemate.global.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@Table(name = "reply")
+public class Reply extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long replyId;
+
+    @Column(nullable = false)
+    private String content;
+
+    @ManyToOne
+    @JoinColumn(name = "comment_id")
+    private Comment comment;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "parent_reply_id")
+    private Reply parentReply;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    public Reply(String content, Comment comment, User user) {
+        this.content = content;
+        this.comment = comment;
+        this.user = user;
+    }
+
+    public Reply(String content, Comment comment, User user,  Reply parentReply) {
+        this.content = content;
+        this.comment = comment;
+        this.user = user;
+        this.parentReply = parentReply;
+    }
+
+    public void updateReply(String content){
+        this.content = content;
+    }
+}

--- a/src/main/java/com/example/gamemate/domain/reply/repository/ReplyRepository.java
+++ b/src/main/java/com/example/gamemate/domain/reply/repository/ReplyRepository.java
@@ -1,0 +1,13 @@
+package com.example.gamemate.domain.reply.repository;
+
+import com.example.gamemate.domain.comment.entity.Comment;
+import com.example.gamemate.domain.reply.entity.Reply;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface ReplyRepository extends JpaRepository<Reply, Long> {
+    List<Reply> findByComment(Comment comment);
+
+    List<Reply> findByParentReply(Reply reply);
+}

--- a/src/main/java/com/example/gamemate/domain/reply/service/ReplyService.java
+++ b/src/main/java/com/example/gamemate/domain/reply/service/ReplyService.java
@@ -1,0 +1,105 @@
+package com.example.gamemate.domain.reply.service;
+
+import com.example.gamemate.domain.comment.entity.Comment;
+import com.example.gamemate.domain.comment.repository.CommentRepository;
+import com.example.gamemate.domain.reply.dto.ReplyRequestDto;
+import com.example.gamemate.domain.reply.dto.ReplyResponseDto;
+import com.example.gamemate.domain.reply.entity.Reply;
+import com.example.gamemate.domain.reply.repository.ReplyRepository;
+import com.example.gamemate.domain.user.entity.User;
+import com.example.gamemate.global.constant.ErrorCode;
+import com.example.gamemate.global.exception.ApiException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ReplyService {
+
+    private final ReplyRepository replyRepository;
+    private final CommentRepository commentRepository;
+
+    /**
+     * 대댓글 생성 메서드
+     * @param commentId
+     * @param requestDto
+     * @return
+     */
+    @Transactional
+    public ReplyResponseDto createReply(User loginUser, Long commentId, ReplyRequestDto requestDto) {
+        //댓글 조회
+        Comment findComment = commentRepository.findById(commentId)
+                .orElseThrow(() -> new ApiException(ErrorCode.COMMENT_NOT_FOUND));
+
+        Reply newReply;
+        // 부모 대댓글 null 일 경우
+        if(requestDto.getParentReplyId()==null){
+            newReply = new Reply(requestDto.getContent(), findComment, loginUser);
+            Reply createReply = replyRepository.save(newReply);
+
+            return new ReplyResponseDto(
+                    createReply.getReplyId(),
+                    createReply.getComment().getCommentId(),
+                    createReply.getContent(),
+                    createReply.getCreatedAt(),
+                    createReply.getModifiedAt()
+            );
+        }else{
+            //대댓글 조회
+            Reply findParentReply = replyRepository.findById(requestDto.getParentReplyId())
+                    .orElseThrow(()-> new ApiException(ErrorCode.COMMENT_NOT_FOUND));
+            newReply = new Reply(requestDto.getContent(), findComment,loginUser, findParentReply);
+            Reply createReply = replyRepository.save(newReply);
+
+            return new ReplyResponseDto(
+                    createReply.getReplyId(),
+                    createReply.getComment().getCommentId(),
+                    createReply.getParentReply().getReplyId(),
+                    createReply.getContent(),
+                    createReply.getCreatedAt(),
+                    createReply.getModifiedAt()
+            );
+        }
+    }
+
+    /**
+     * 대댓글 업데이트 메서드
+     * @param id
+     * @param requestDto
+     */
+    @Transactional
+    public void updateReply(User loginUser, Long id, ReplyRequestDto requestDto) {
+        // 대댓글 조회
+        Reply findReply = replyRepository.findById(id)
+                .orElseThrow(() -> new ApiException(ErrorCode.COMMENT_NOT_FOUND));
+
+        // 대댓글 작성자와 로그인 유저 확인
+        if(!findReply.getUser().getId().equals(loginUser.getId())) {
+            throw new ApiException(ErrorCode.FORBIDDEN);
+        }
+
+        findReply.updateReply(requestDto.getContent());
+        replyRepository.save(findReply);
+    }
+
+    /**
+     * 대댓글 삭제 메서드
+     * @param id
+     */
+    @Transactional
+    public void deleteReply(User loginUser, Long id) {
+        // 대댓글 조회
+        Reply findReply = replyRepository.findById(id)
+                .orElseThrow(() -> new ApiException(ErrorCode.COMMENT_NOT_FOUND));
+
+        // 대댓글 작성자와 로그인 유저 확인
+        if(!findReply.getUser().getId().equals(loginUser.getId())) {
+            throw new ApiException(ErrorCode.FORBIDDEN);
+        }
+
+        replyRepository.delete(findReply);
+    }
+}


### PR DESCRIPTION
1. 대댓글 생성
2. 대댓글 수정
3. 대댓글 삭제
4. 게시판 단건 조회 시 대댓글 출력
5. 게시판 단건 조회 시에 게시판, 댓글에 작성자 이름 출력하도록 수정

## #️⃣연관된 이슈

> #24 

## 📝작업 내용

> 대댓글 기능 구현 

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰 부탁드립니다.
> 게시판과 댓글/대댓글 API는 추후에 분리할 예정입니다.
