### PR TITLE
feat: 게시글과 댓글/ 대댓글 API 분리

### DIFF
--- a/src/main/java/com/example/gamemate/domain/board/controller/BoardController.java
+++ b/src/main/java/com/example/gamemate/domain/board/controller/BoardController.java
@@ -12,9 +12,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.Authentication;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -67,17 +65,15 @@ public class BoardController {
 
     /**
      * 게시글 단건 조회 API
-     * @param page
      * @param id
      * @return
      */
     @GetMapping("/{id}")
     public ResponseEntity<BoardFindOneResponseDto> findBoardById(
-            @RequestParam(required = false, defaultValue = "0") int page,
             @PathVariable Long id
     ){
 
-        BoardFindOneResponseDto dto = boardService.findBoardById(page,id);
+        BoardFindOneResponseDto dto = boardService.findBoardById(id);
         return new ResponseEntity<>(dto, HttpStatus.OK);
     }
 

--- a/src/main/java/com/example/gamemate/domain/board/dto/BoardFindOneResponseDto.java
+++ b/src/main/java/com/example/gamemate/domain/board/dto/BoardFindOneResponseDto.java
@@ -17,9 +17,8 @@ public class BoardFindOneResponseDto {
     private final String nickname;
     private final LocalDateTime createdAt;
     private final LocalDateTime modifiedAt;
-    private final List<CommentFindResponseDto> comments;
 
-    public BoardFindOneResponseDto(Long id, BoardCategory category, String title, String content, String nickname, LocalDateTime createdAt, LocalDateTime modifiedAt, List<CommentFindResponseDto> comments) {
+    public BoardFindOneResponseDto(Long id, BoardCategory category, String title, String content, String nickname, LocalDateTime createdAt, LocalDateTime modifiedAt) {
         this.id = id;
         this.category = category;
         this.title = title;
@@ -27,6 +26,5 @@ public class BoardFindOneResponseDto {
         this.nickname = nickname;
         this.createdAt = createdAt;
         this.modifiedAt = modifiedAt;
-        this.comments = comments;
     }
 }

--- a/src/main/java/com/example/gamemate/domain/board/enums/ListSize.java
+++ b/src/main/java/com/example/gamemate/domain/board/enums/ListSize.java
@@ -4,7 +4,9 @@ import lombok.Getter;
 
 @Getter
 public enum ListSize {
-    LIST_SIZE(15);
+    BOARD_LIST_SIZE(15),
+    COMMENT_LIST_SIZE(25),;
+
 
     private final int size;
     ListSize(int size) {

--- a/src/main/java/com/example/gamemate/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/example/gamemate/domain/comment/controller/CommentController.java
@@ -1,5 +1,6 @@
 package com.example.gamemate.domain.comment.controller;
 
+import com.example.gamemate.domain.comment.dto.CommentFindResponseDto;
 import com.example.gamemate.domain.comment.dto.CommentRequestDto;
 import com.example.gamemate.domain.comment.dto.CommentResponseDto;
 import com.example.gamemate.domain.comment.service.CommentService;
@@ -9,6 +10,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RequiredArgsConstructor
 @RestController
@@ -31,6 +34,21 @@ public class CommentController {
     ){
         CommentResponseDto dto = commentService.createComment(customUserDetails.getUser(),boardId, requestDto);
         return new ResponseEntity<>(dto, HttpStatus.CREATED);
+    }
+
+    /**
+     * 댓글/대댓글 조회
+     * @param boardId
+     * @param page
+     * @return
+     */
+    @GetMapping
+    public ResponseEntity<List<CommentFindResponseDto>> getComments(
+            @PathVariable Long boardId,
+            @RequestParam(defaultValue = "0") int page
+    ){
+        List<CommentFindResponseDto> dtos = commentService.getComments(boardId, page);
+        return new ResponseEntity<>(dtos, HttpStatus.OK);
     }
 
     /**

--- a/src/main/java/com/example/gamemate/domain/comment/service/CommentService.java
+++ b/src/main/java/com/example/gamemate/domain/comment/service/CommentService.java
@@ -1,23 +1,38 @@
 package com.example.gamemate.domain.comment.service;
 
 import com.example.gamemate.domain.board.entity.Board;
+import com.example.gamemate.domain.board.enums.ListSize;
 import com.example.gamemate.domain.board.repository.BoardRepository;
+import com.example.gamemate.domain.comment.dto.CommentFindResponseDto;
 import com.example.gamemate.domain.comment.dto.CommentRequestDto;
 import com.example.gamemate.domain.comment.dto.CommentResponseDto;
 import com.example.gamemate.domain.comment.entity.Comment;
 import com.example.gamemate.domain.comment.repository.CommentRepository;
+import com.example.gamemate.domain.reply.dto.ReplyFindResponseDto;
+import com.example.gamemate.domain.reply.entity.Reply;
+import com.example.gamemate.domain.reply.repository.ReplyRepository;
 import com.example.gamemate.domain.user.entity.User;
 import com.example.gamemate.global.constant.ErrorCode;
 import com.example.gamemate.global.exception.ApiException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 public class CommentService {
 
     private final CommentRepository commentRepository;
+    private final ReplyRepository replyRepository;
     private final BoardRepository boardRepository;
 
     /**
@@ -80,5 +95,54 @@ public class CommentService {
         }
 
         commentRepository.delete(findComment);
+    }
+
+    /**
+     * 댓글 조회 메서드
+     * @param boardId
+     * @param page
+     * @return
+     */
+    public List<CommentFindResponseDto> getComments(Long boardId, int page) {
+        // page는 댓글 페이지네이션을 위해 필요
+        Pageable pageable = PageRequest.of(page, ListSize.COMMENT_LIST_SIZE.getSize(), Sort.by(Sort.Order.asc("createdAt")));
+
+        //게시글 조회
+        Board findBoard = boardRepository.findById(boardId)
+                .orElseThrow(()->new ApiException(ErrorCode.BOARD_NOT_FOUND));
+
+        // 댓글 조회
+        Page<Comment> comments = commentRepository.findByBoard(findBoard,pageable);
+
+        return comments.stream()
+                .map(this::convertCommentDto)
+                .collect(Collectors.toList());
+    }
+
+    private CommentFindResponseDto convertCommentDto(Comment comment) {
+        List<ReplyFindResponseDto> replyDtos = Optional.ofNullable(replyRepository.findByComment(comment))
+                .orElse(Collections.emptyList())
+                .stream()
+                .map(this::convertReplyDto)
+                .collect(Collectors.toList());
+        return new CommentFindResponseDto(
+                comment.getCommentId(),
+                comment.getContent(),
+                comment.getUser().getNickname(),
+                comment.getCreatedAt(),
+                comment.getModifiedAt(),
+                replyDtos
+        );
+    }
+
+    private ReplyFindResponseDto convertReplyDto(Reply reply) {
+        String findUserName = reply.getParentReply() == null ? null : reply.getParentReply().getUser().getNickname();
+        return new ReplyFindResponseDto(
+                reply.getReplyId(),
+                findUserName,
+                reply.getContent(),
+                reply.getCreatedAt(),
+                reply.getModifiedAt()
+        );
     }
 }


### PR DESCRIPTION
1. 게시글 조회와 댓글/대댓글 조회 분리

## #️⃣연관된 이슈

> #43 

## 📝작업 내용

> 게시글 조회와 댓글/대댓글 조회 분리 

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰 부탁드립니다.
